### PR TITLE
popconfirm: fix event name and also add doc; fix title style

### DIFF
--- a/examples/docs/zh-CN/popconfirm.md
+++ b/examples/docs/zh-CN/popconfirm.md
@@ -10,10 +10,24 @@ Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考
 <template>
 <el-popconfirm
   title="这是一段内容确定删除吗？"
+  @on-confirm="onConfirm"
+  @on-cancel="onCancel"
 >
   <el-button slot="reference">删除</el-button>
 </el-popconfirm>
 </template>
+<script>
+  export default {
+    methods: {
+      onConfirm(e) {
+        alert('点击了确认按钮：' + e)
+      },
+      onCancel(e) {
+        alert('点击了取消按钮：' + e)
+      }
+    }
+  }
+</script>
 ````
 :::
 
@@ -52,3 +66,9 @@ Popconfirm 的属性与 Popover 很类似，因此对于重复属性，请参考
 | 参数 | 说明 |
 |--- | ---|
 | reference | 触发 Popconfirm 显示的 HTML 元素 |
+
+### Events
+| 事件名 | 说明 | 参数 |
+| ---- | ---- | ---- |
+| on-confirm | 点击确认按钮时触发 | event |
+| on-cancel | 点击确认按钮时触发 | event |

--- a/packages/popconfirm/src/main.vue
+++ b/packages/popconfirm/src/main.vue
@@ -6,25 +6,25 @@
   >
   <div class="el-popconfirm">
     <p class="el-popconfirm__main">
-    <i
-      v-if="!hideIcon"
-      :class="icon"
-      class="el-popconfirm__icon"
-      :style="{color: iconColor}"
-    ></i>
+      <i
+        v-if="!hideIcon"
+        :class="icon"
+        class="el-popconfirm__icon"
+        :style="{color: iconColor}"
+      ></i>
       {{title}}
     </p>
     <div class="el-popconfirm__action">
-      <el-button 
-        size="mini" 
-        :type="cancelButtonType" 
+      <el-button
+        size="mini"
+        :type="cancelButtonType"
         @click="cancel"
       >
         {{cancelButtonText}}
       </el-button>
-      <el-button 
-        size="mini" 
-        :type="confirmButtonType" 
+      <el-button
+        size="mini"
+        :type="confirmButtonType"
         @click="confirm"
       >
         {{confirmButtonText}}
@@ -85,13 +85,13 @@ export default {
     };
   },
   methods: {
-    confirm() {
+    confirm(e) {
       this.visible = false;
-      this.$emit('onConfirm');
+      this.$emit('on-confirm', e);
     },
-    cancel() {
+    cancel(e) {
       this.visible = false;
-      this.$emit('onCancel');
+      this.$emit('on-cancel', e);
     }
   }
 };

--- a/packages/theme-chalk/src/popconfirm.scss
+++ b/packages/theme-chalk/src/popconfirm.scss
@@ -5,12 +5,13 @@
   @include e(main) {
     display: flex;
     align-items: center;
+    margin-top: 0;
   }
   @include e(icon) {
     margin-right: 5px;
   }
   @include e(action) {
-    text-align: right; 
-    margin: 0
+    text-align: right;
+    margin: 0;
   }
 }


### PR DESCRIPTION
https://github.com/ElemeFE/element/issues/18456

* 其他组件的事件名都是 `on-xxx`，唯独这里用的是驼峰。。。
* 另外移除了一段p标签自带的多余的margin

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
