### PR TITLE
select: fix clicking the arrow won't collapse the selection list when filterable

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -96,8 +96,8 @@
         <slot name="prefix"></slot>
       </template>
       <template slot="suffix">
-        <i v-show="!showClose" :class="['el-select__caret', 'el-input__icon', 'el-icon-' + iconClass]"></i>
-        <i v-if="showClose" class="el-select__caret el-input__icon el-icon-circle-close" @click="handleClearClick"></i>
+        <i v-if="!showClose" :class="['el-select__caret', 'el-input__icon', 'el-icon-' + iconClass]" @click="toggleList"></i>
+        <i v-else class="el-select__caret el-input__icon el-icon-circle-close" @click="handleClearClick"></i>
       </template>
     </el-input>
     <transition
@@ -574,6 +574,13 @@
           this.$emit('focus', event);
         } else {
           this.softFocus = false;
+        }
+      },
+
+      toggleList(event) {
+        if (this.visible) {
+          this.visible = false;
+          event.stopPropagation();
         }
       },
 


### PR DESCRIPTION
修复：当select可过滤时（有filterable属性），点击下箭头不会关闭下拉框

![image](https://user-images.githubusercontent.com/6134068/77742640-bd5ef400-7051-11ea-91d3-ffaafa9acb6a.png)

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
