### PR TITLE
scrollbar: use native style when possible; vertical scroll by default

### DIFF
--- a/examples/pages/template/component.tpl
+++ b/examples/pages/template/component.tpl
@@ -24,11 +24,6 @@
       margin-top: 80px;
       transition: padding-top .3s;
 
-      > .el-scrollbar__wrap {
-        height: 100%;
-        overflow-x: auto;
-      }
-
       &.is-extended {
         padding-top: 0;
       }

--- a/packages/scrollbar/src/bar.js
+++ b/packages/scrollbar/src/bar.js
@@ -26,11 +26,12 @@ export default {
 
     return (
       <div
-        class={ ['el-scrollbar__bar', 'is-' + bar.key] }
+        staticClass="el-scrollbar__bar"
+        class={ 'is-' + bar.key }
         onMousedown={ this.clickTrackHandler } >
         <div
           ref="thumb"
-          class="el-scrollbar__thumb"
+          staticClass="el-scrollbar__thumb"
           onMousedown={ this.clickThumbHandler }
           style={ renderThumbStyle({ size, move, bar }) }>
         </div>

--- a/packages/theme-chalk/src/date-picker/time-spinner.scss
+++ b/packages/theme-chalk/src/date-picker/time-spinner.scss
@@ -15,10 +15,6 @@
     vertical-align: top;
     position: relative;
 
-    & .el-scrollbar__wrap:not(.el-scrollbar__wrap--hidden-default) {
-      padding-bottom: 15px;
-    }
-
     @include when(arrow) {
       box-sizing: border-box;
       text-align: center;

--- a/packages/theme-chalk/src/scrollbar.scss
+++ b/packages/theme-chalk/src/scrollbar.scss
@@ -2,70 +2,103 @@
 @import "common/var";
 
 @include b(scrollbar) {
-  overflow: hidden;
-  position: relative;
-
-  &:hover,
-  &:active,
-  &:focus {
-    > .el-scrollbar__bar {
-      opacity: 1;
-      transition: opacity 340ms ease-out;
-    }
-  }
-
-  @include e(wrap) {
-    overflow: scroll;
-    height: 100%;
-
-    @include m(hidden-default) {
-      scrollbar-width: none;
-      &::-webkit-scrollbar {
-        width: 0;
-        height: 0;
-      }
-    }
-  }
-
-  @include e(thumb) {
+  @include when(simulated) {
+    overflow: hidden;
     position: relative;
-    display: block;
-    width: 0;
-    height: 0;
-    cursor: pointer;
-    border-radius: inherit;
-    background-color: $--scrollbar-background-color;
-    transition: .3s background-color;
 
-    &:hover {
-      background-color: $--scrollbar-hover-background-color;
-    }
-  }
-
-  @include e(bar) {
-    position: absolute;
-    right: 2px;
-    bottom: 2px;
-    z-index: 1;
-    border-radius: 4px;
-    opacity: 0;
-    transition: opacity 120ms ease-out;
-
-    @include when(vertical) {
-      width: 6px;
-      top: 2px;
-
-      > div {
-        width: 100%;
+    &:hover,
+    &:active,
+    &:focus {
+      > .el-scrollbar__bar {
+        opacity: 1;
+        transition: opacity 340ms ease-out;
       }
     }
 
-    @include when(horizontal) {
-      height: 6px;
-      left: 2px;
+    @include e(wrap) {
+      overflow: scroll;
+      height: 100%;
 
-      > div {
-        height: 100%;
+      @include m(hidden-default) {
+        scrollbar-width: none;
+        &::-webkit-scrollbar {
+          width: 0;
+          height: 0;
+          display: none;
+        }
+      }
+    }
+
+    @include e(thumb) {
+      position: relative;
+      display: block;
+      width: 0;
+      height: 0;
+      cursor: pointer;
+      border-radius: inherit;
+      background-color: $--scrollbar-background-color;
+      transition: .3s background-color;
+
+      &:hover {
+        background-color: $--scrollbar-hover-background-color;
+      }
+    }
+
+    @include e(bar) {
+      position: absolute;
+      right: 2px;
+      bottom: 2px;
+      z-index: 1;
+      border-radius: 4px;
+      opacity: 0;
+      transition: opacity 120ms ease-out;
+
+      @include when(vertical) {
+        width: 6px;
+        top: 2px;
+
+        > div {
+          width: 100%;
+        }
+      }
+
+      @include when(horizontal) {
+        height: 6px;
+        left: 2px;
+
+        > div {
+          height: 100%;
+        }
+      }
+    }
+  }
+
+  @include when(native) {
+    @include e(wrap) {
+      overflow: overlay;
+      height: 100%;
+      margin-right: 2px;
+
+      &::-webkit-scrollbar {
+        width: 6px;
+        height: 6px;
+      }
+
+      &:not(:hover)::-webkit-scrollbar {
+        display: none;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: none;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        border-radius: 4px;
+        background: $--scrollbar-background-color;
+
+        &:hover {
+          background: $--scrollbar-hover-background-color;
+        }
       }
     }
   }

--- a/src/utils/popup/index.js
+++ b/src/utils/popup/index.js
@@ -3,10 +3,7 @@ import merge from 'element-ui/src/utils/merge';
 import PopupManager from 'element-ui/src/utils/popup/popup-manager';
 import getScrollBarWidth from '../scrollbar-width';
 import { getStyle, addClass, removeClass, hasClass } from '../dom';
-
-let idSeed = 1;
-
-let scrollBarWidth;
+import { generateId } from 'element-ui/src/utils/util';
 
 export default {
   props: {
@@ -45,7 +42,7 @@ export default {
   },
 
   beforeMount() {
-    this._popupId = 'popup-' + idSeed++;
+    this._popupId = 'popup-' + generateId();
     PopupManager.register(this._popupId, this);
   },
 
@@ -135,9 +132,9 @@ export default {
           this.withoutHiddenClass = !hasClass(document.body, 'el-popup-parent--hidden');
           if (this.withoutHiddenClass) {
             this.bodyPaddingRight = document.body.style.paddingRight;
-            this.computedBodyPaddingRight = parseInt(getStyle(document.body, 'paddingRight'), 10);
+            this.computedBodyPaddingRight = parseFloat(getStyle(document.body, 'paddingRight'));
           }
-          scrollBarWidth = getScrollBarWidth();
+          const scrollBarWidth = getScrollBarWidth();
           let bodyHasOverflow = document.documentElement.clientHeight < document.body.scrollHeight;
           let bodyOverflowY = getStyle(document.body, 'overflowY');
           if (scrollBarWidth > 0 && (bodyHasOverflow || bodyOverflowY === 'scroll') && this.withoutHiddenClass) {

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -23,17 +23,6 @@ function extend(target, source) {
   return target;
 }
 
-/** @param {object[]} arr */
-export function toObject(arr) {
-  var res = {};
-  for (let i = 0; i < arr.length; i++) {
-    if (arr[i]) {
-      extend(res, arr[i]);
-    }
-  }
-  return res;
-};
-
 /** @param {object} object */
 export function getValueByPath(object, prop = '') {
   const paths = prop.split('.');
@@ -82,8 +71,9 @@ export function getPropByPath(obj, path, strict) {
   };
 };
 
+let idSeed = 0;
 export function generateId() {
-  return Math.floor(Math.random() * 10000);
+  return ++idSeed;
 }
 
 export function valueEquals(a, b) {
@@ -141,6 +131,10 @@ export function coerceTruthyValueToArray(val) {
   }
 }
 
+export function isChromeLike() {
+  return !Vue.prototype.$isServer && navigator.userAgent.indexOf('Chrome') > -1;
+}
+
 export function isIE() {
   return !Vue.prototype.$isServer && !isNaN(Number(document.documentMode));
 }
@@ -150,7 +144,7 @@ export function isEdge() {
 }
 
 export function isFirefox() {
-  return !Vue.prototype.$isServer && !!window.navigator.userAgent.match(/firefox/i);
+  return !Vue.prototype.$isServer && !!navigator.userAgent.match(/firefox/i);
 }
 
 /** @param {CSSStyleSheet} style */


### PR DESCRIPTION
在Chrome浏览器中默认使用原生 `::webkit-scroller` 实现样式修改，另外默认纵向滚动

This is a breaking change. But since `el-scrollbar` is not publicly
documented and 90% scrollbars are vertical, I suppose it should not
break existing code.

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
