### PR TITLE
form: make disabled form can have enabled components

### DIFF
--- a/examples/components/theme-configurator/editor/color-picker/src/main.vue
+++ b/examples/components/theme-configurator/editor/color-picker/src/main.vue
@@ -36,6 +36,7 @@
   import PickerDropdown from './components/picker-dropdown.vue';
   import Clickoutside from 'element-ui/src/utils/clickoutside';
   import Emitter from 'element-ui/src/mixins/emitter';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElColorPicker',
@@ -46,7 +47,10 @@
       value: String,
       showAlpha: Boolean,
       colorFormat: String,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       size: String,
       popperClass: String,
       predefine: Array,
@@ -82,7 +86,7 @@
       },
 
       colorDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       }
     },
 

--- a/examples/docs/en-US/form.md
+++ b/examples/docs/en-US/form.md
@@ -601,7 +601,7 @@ All components in a Form inherit their `size` attribute from that Form. Similarl
 | status-icon  | whether to display an icon indicating the validation result | boolean | — | false |
 | validate-on-rule-change  | whether to trigger validation when the `rules` prop is changed | boolean | — | true |
 | size  | control the size of components in this form | string | medium / small / mini | — |
-| disabled | whether to disabled all components in this form. If set to true, it cannot be overridden by its inner components' `disabled` prop | boolean | — | false |
+| disabled | whether to disabled all components which don't set `disabled` prop in this form | boolean | — | false |
 
 ### Form Methods
 

--- a/examples/docs/zh-CN/button.md
+++ b/examples/docs/zh-CN/button.md
@@ -154,13 +154,13 @@ Button 组件提供除了默认值以外的三种尺寸，可以在不同场景�
 ### Attributes
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |
-| size     | 尺寸   | string  |   medium / small / mini            |    —     |
-| type     | 类型   | string    |   primary / success / warning / danger / info / text |     —    |
+| size      | 尺寸   | string  |   medium / small / mini            |    —     |
+| type      | 类型   | string    |   primary / success / warning / danger / info / text |     —    |
 | plain     | 是否朴素按钮   | boolean    | — | false   |
 | round     | 是否圆角按钮   | boolean    | — | false   |
-| circle     | 是否圆形按钮   | boolean    | — | false   |
-| loading     | 是否加载中状态   | boolean    | — | false   |
-| disabled  | 是否禁用状态    | boolean   | —   | false   |
-| icon  | 图标类名 | string   |  —  |  —  |
-| autofocus  | 是否默认聚焦 | boolean   |  —  |  false  |
+| circle    | 是否圆形按钮   | boolean    | — | false   |
+| loading   | 是否加载中状态   | boolean    | — | false   |
+| disabled  | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
+| icon      | 图标类名 | string   |  —  |  —  |
+| autofocus | 是否默认聚焦 | boolean   |  —  |  false  |
 | native-type | 原生 type 属性 | string | button / submit / reset | button |

--- a/examples/docs/zh-CN/cascader.md
+++ b/examples/docs/zh-CN/cascader.md
@@ -1894,7 +1894,7 @@
 | props | 配置选项，具体见下表 | object | — | — |
 | size | 尺寸 | string | medium / small / mini | — |
 | placeholder | 输入框占位文本 | string | — | 请选择 |
-| disabled | 是否禁用 | boolean | — | false |
+| disabled      | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | clearable | 是否支持清空选项 | boolean | — | false |
 | show-all-levels | 输入框中是否显示选中值的完整路径 | boolean | — | true |
 | collapse-tags | 多选模式下是否折叠Tag | boolean | - | false |

--- a/examples/docs/zh-CN/checkbox.md
+++ b/examples/docs/zh-CN/checkbox.md
@@ -278,6 +278,6 @@
 | label     | 选中状态的值（只有在`checkbox-group`或者绑定对象类型为`array`时有效）| string / number / boolean  |       —        |     —    |
 | true-label | 选中时的值   | string / number | — |     —    |
 | false-label | 没有选中时的值   | string / number    |      —         |     —    |
-| disabled  | 是否禁用    | boolean   |  — | false   |
+| disabled  | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | name | 原生 name 属性 | string    |      —         |     —    |
 | checked  | 当前是否勾选    | boolean   |  — | false   |

--- a/examples/docs/zh-CN/color-picker.md
+++ b/examples/docs/zh-CN/color-picker.md
@@ -9,8 +9,7 @@
 <div class="block">
   <span class="demonstration">有默认值</span>
   <el-color-picker v-model="color1"></el-color-picker>
-</div>
-<div class="block">
+</div><div class="block">
   <span class="demonstration">无默认值</span>
   <el-color-picker v-model="color2"></el-color-picker>
 </div>
@@ -21,6 +20,24 @@
       return {
         color1: '#409EFF',
         color2: null
+      }
+    }
+  };
+</script>
+```
+:::
+
+### 禁用
+
+:::demo 设置 `disabled` 属性禁用
+```html
+<el-color-picker v-model="color" disabled></el-color-picker>
+
+<script>
+  export default {
+    data() {
+      return {
+        color: '#409EFF'
       }
     }
   };
@@ -109,7 +126,7 @@
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |
 | value / v-model | 绑定值 | string | — | — |
-| disabled | 是否禁用 | boolean | — | false |
+| disabled      | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | size | 尺寸 | string | — | medium / small / mini |
 | show-alpha | 是否支持透明度选择 | boolean | — | false |
 | color-format | 写入 v-model 的颜色的格式 | string | hsl / hsv / hex / rgb | hex（show-alpha 为 false）/ rgb（show-alpha 为 true） |

--- a/examples/docs/zh-CN/form.md
+++ b/examples/docs/zh-CN/form.md
@@ -91,7 +91,7 @@ W3C 标准中有如下[规定](https://www.w3.org/MarkUp/html-spec/html-spec_8.h
 
 :::demo 设置 `inline` 属性可以让表单域变为行内的表单域
 ```html
-<el-form :inline="true" :model="formInline" class="demo-form-inline">
+<el-form inline :model="formInline" class="demo-form-inline">
   <el-form-item label="审批人">
     <el-input v-model="formInline.user" placeholder="审批人"></el-input>
   </el-form-item>
@@ -159,6 +159,64 @@ W3C 标准中有如下[规定](https://www.w3.org/MarkUp/html-spec/html-spec_8.h
           type: ''
         }
       };
+    }
+  }
+</script>
+```
+:::
+
+### 禁用表单
+
+:::demo 设置 `disabled` 属性可以禁用所有未显式指定 `:disabled="false"` 的输入组件
+```html
+<el-form :model="form" label-width="80px" disabled>
+  <el-form-item label="审批人">
+    <el-input v-model="form.user" placeholder="审批人"></el-input>
+  </el-form-item>
+  <el-form-item label="活动区域">
+    <el-select v-model="form.region" placeholder="活动区域">
+      <el-option label="区域一" value="shanghai"></el-option>
+      <el-option label="区域二" value="beijing"></el-option>
+    </el-select>
+  </el-form-item>
+  <el-form-item label="活动性质">
+    <el-checkbox-group v-model="form.type">
+      <el-checkbox label="美食/餐厅线上活动" name="type"></el-checkbox>
+      <el-checkbox label="地推活动" name="type"></el-checkbox>
+      <el-checkbox label="线下主题活动" name="type"></el-checkbox>
+      <el-checkbox label="单纯品牌曝光" name="type"></el-checkbox>
+    </el-checkbox-group>
+  </el-form-item>
+  <el-form-item label="特殊资源">
+    <el-radio-group v-model="form.resource">
+      <el-radio label="线上品牌商赞助"></el-radio>
+      <el-radio label="线下场地免费"></el-radio>
+    </el-radio-group>
+  </el-form-item>
+  <el-form-item>
+    <el-button type="primary" @click="onSubmit">查询</el-button>
+    <el-button type="primary" @click="onClose" :disabled="false">关闭</el-button>
+  </el-form-item>
+</el-form>
+<script>
+  export default {
+    data() {
+      return {
+        form: {
+          user: '',
+          region: '',
+          type: [],
+          resource: ''
+        }
+      }
+    },
+    methods: {
+      onSubmit() {
+        console.log('submit!');
+      },
+      onClose() {
+        console.log('close!');
+      }
     }
   }
 </script>
@@ -641,7 +699,7 @@ W3C 标准中有如下[规定](https://www.w3.org/MarkUp/html-spec/html-spec_8.h
 | status-icon  | 是否在输入框中显示校验结果反馈图标 | boolean | — | false |
 | validate-on-rule-change  | 是否在 `rules` 属性改变后立即触发一次验证 | boolean | — | true |
 | size  | 用于控制该表单内组件的尺寸 | string | medium / small / mini | — |
-| disabled | 是否禁用该表单内的所有组件。若设置为 true，则表单内组件上的 disabled 属性不再生效 | boolean | — | false |
+| disabled | 是否禁用该表单内的所有未显式指定 `disabled` 属性的组件 | boolean | — | false |
 
 ### Form Methods
 

--- a/examples/docs/zh-CN/input-number.md
+++ b/examples/docs/zh-CN/input-number.md
@@ -175,7 +175,7 @@
 | step-strictly | 是否只能输入 step 的倍数 | boolean   | — | false |
 | precision| 数值精度             | number   | — | — |
 | size     | 计数器尺寸           | string   | medium / small / mini | — |
-| disabled | 是否禁用计数器        | boolean | — | false |
+| disabled | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | controls | 是否使用控制按钮        | boolean | — | true |
 | controls-position | 控制按钮位置 | string | right | - |
 | name | 原生属性 | string | — | — |

--- a/examples/docs/zh-CN/input.md
+++ b/examples/docs/zh-CN/input.md
@@ -793,7 +793,7 @@ export default {
 | placeholder   | 输入框占位文本    | string          | — | — |
 | clearable     | 是否可清空        | boolean         | — | false |
 | show-password | 是否显示切换密码图标| boolean         | — | false |
-| disabled      | 禁用            | boolean         | — | false   |
+| disabled      | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | size          | 输入框尺寸，只在 `type!="textarea"` 时有效      | string          | medium / small / mini  | — |
 | prefix-icon   | 输入框头部图标    | string          | — | — |
 | suffix-icon   | 输入框尾部图标    | string          | — | — |

--- a/examples/docs/zh-CN/link.md
+++ b/examples/docs/zh-CN/link.md
@@ -84,7 +84,7 @@
 | -------------- | ------------------------------ | --------- | ------------------------------------ | ------- |
 | type           | 类型                      | string  | primary / success / warning / danger / info / native | default |
 | underline      | 是否下划线                         | boolean | —                                 | true    |
-| disabled       | 是否禁用状态                       | boolean | —                                 | false   |
+| disabled       | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | inherit-fs     | 是否继承父级的字号大小             | boolean | —                                 | false   |
 | href           | 原生 href 属性                     | string  | —                                 | -       |
 | to             | 跳转路由对象。注意如此参数非空会忽略 href 参数 | string / object | —             | -       |

--- a/examples/docs/zh-CN/radio.md
+++ b/examples/docs/zh-CN/radio.md
@@ -207,5 +207,5 @@
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |
 | label     | Radio 的 value  | string / number  |        —       |     —    |
-| disabled  | 是否禁用    | boolean   | — | false   |
+| disabled  | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | name | 原生 name 属性 | string    |      —         |     —    |

--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -628,7 +628,7 @@
 |---------- |-------------- |---------- |--------------------------------  |-------- |
 | value / v-model | 绑定值 | boolean / string / number | — | — |
 | multiple | 是否多选 | boolean | — | false |
-| disabled | 是否禁用 | boolean | — | false |
+| disabled | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | value-key | 作为 value 唯一标识的键名，绑定值为对象类型时必填 | string | — | value |
 | label-key | 当绑定值为对象类型且未匹配到选项时（比如正在加载数据），用以获取绑定值中的展示内容 | string | - | label |
 | size | 输入框尺寸 | string | medium/small/mini | — |

--- a/examples/docs/zh-CN/slider.md
+++ b/examples/docs/zh-CN/slider.md
@@ -233,7 +233,7 @@
 | value / v-model | 绑定值，非范围选择时为数字，范围选择时为数字的数组 | number / [number, number] | — | 0 |
 | min | 最小值 | number | — | 0 |
 | max | 最大值 | number | — | 100 |
-| disabled | 是否禁用 | boolean | — | false |
+| disabled  | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | step | 步长 | number | — | 1 |
 | show-input | 是否显示输入框，仅在非范围选择时有效 | boolean | — | false |
 | show-input-controls | 在显示输入框的情况下，是否显示输入框的控制按钮 | boolean | — | true |

--- a/examples/docs/zh-CN/upload.md
+++ b/examples/docs/zh-CN/upload.md
@@ -373,7 +373,7 @@
 | auto-upload | 是否在选取文件后立即进行上传 | boolean | — | true |
 | file-list | 上传的文件列表, 例如: [{name: 'food.jpg', url: 'https://xxx.cdn.com/xxx.jpg'}] | array | — | [] |
 | http-request | 覆盖默认的上传行为，可以自定义上传的实现 | function | — | — |
-| disabled | 是否禁用 | boolean | — | false |
+| disabled  | 是否禁用。`null` 表示继承父级表单的禁用状态 | boolean | true, false, null | null   |
 | limit | 最大允许上传个数 |  number | — | — |
 | on-exceed | 文件超出个数限制时的钩子 | function(files, fileList) | — | - |
 

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -95,7 +95,10 @@
         type: Boolean,
         default: false
       },
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       name: String,
       size: String,
       value: String,

--- a/packages/button/src/button.vue
+++ b/packages/button/src/button.vue
@@ -5,17 +5,15 @@
     :disabled="buttonDisabled || loading"
     :autofocus="autofocus"
     :type="nativeType"
-    :class="[
-      type ? 'el-button--' + type : '',
-      buttonSize ? 'el-button--' + buttonSize : '',
-      {
-        'is-disabled': buttonDisabled,
-        'is-loading': loading,
-        'is-plain': plain,
-        'is-round': round,
-        'is-circle': circle
-      }
-    ]"
+    :class="{
+      ['el-button--' + type]: type,
+      ['el-button--' + buttonSize]: buttonSize,
+      'is-disabled': buttonDisabled,
+      'is-loading': loading,
+      'is-plain': plain,
+      'is-round': round,
+      'is-circle': circle
+    }"
   >
     <i class="el-icon-loading" v-if="loading"></i>
     <i :class="icon" v-if="icon && !loading"></i>
@@ -23,6 +21,8 @@
   </button>
 </template>
 <script>
+  import { calcDisabled } from 'element-ui/src/utils/util';
+
   export default {
     name: 'ElButton',
 
@@ -50,7 +50,10 @@
         default: 'button'
       },
       loading: Boolean,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       plain: Boolean,
       autofocus: Boolean,
       round: Boolean,
@@ -65,7 +68,7 @@
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;
       },
       buttonDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       }
     },
 

--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -124,7 +124,7 @@ import ElScrollbar from 'element-ui/packages/scrollbar';
 import ElCascaderPanel from 'element-ui/packages/cascader-panel';
 import AriaUtils from 'element-ui/src/utils/aria-utils';
 import { t } from 'element-ui/src/locale';
-import { isEqual, isEmpty, kebabCase } from 'element-ui/src/utils/util';
+import { isEqual, isEmpty, kebabCase, calcDisabled } from 'element-ui/src/utils/util';
 import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
 import { debounce } from 'throttle-debounce';
 
@@ -186,7 +186,10 @@ export default {
       type: String,
       default: () => t('el.cascader.placeholder')
     },
-    disabled: Boolean,
+    disabled: {
+      type: Boolean,
+      default: null
+    },
     clearable: Boolean,
     filterable: Boolean,
     filterMethod: Function,
@@ -238,7 +241,7 @@ export default {
         : 'small';
     },
     isDisabled() {
-      return this.disabled || !!(this.elForm || {}).disabled;
+      return calcDisabled(this.disabled, this.elForm);
     },
     config() {
       const config = this.props || {};

--- a/packages/checkbox/src/checkbox-button.vue
+++ b/packages/checkbox/src/checkbox-button.vue
@@ -1,12 +1,12 @@
 <template>
   <label
     class="el-checkbox-button"
-      :class="[
-        size ? 'el-checkbox-button--' + size : '',
-        { 'is-disabled': isDisabled },
-        { 'is-checked': isChecked },
-        { 'is-focus': focus },
-      ]"
+    :class="[
+      size ? 'el-checkbox-button--' + size : '',
+      { 'is-disabled': isDisabled },
+      { 'is-checked': isChecked },
+      { 'is-focus': focus },
+    ]"
     role="checkbox"
     :aria-checked="isChecked"
     :aria-disabled="isDisabled"
@@ -45,6 +45,7 @@
 </template>
 <script>
   import Emitter from 'element-ui/src/mixins/emitter';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElCheckboxButton',
@@ -71,7 +72,10 @@
     props: {
       value: {},
       label: {},
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       checked: Boolean,
       name: String,
       trueLabel: [String, Number],
@@ -161,7 +165,7 @@
       isDisabled() {
         return (this._checkboxGroup
           ? this._checkboxGroup.disabled || this.isLimitDisabled
-          : false) || this.disabled || !!(this.elForm || {}).disabled;
+          : false) || calcDisabled(this.disabled, this.elForm);
       }
     },
     methods: {

--- a/packages/checkbox/src/checkbox-group.vue
+++ b/packages/checkbox/src/checkbox-group.vue
@@ -1,3 +1,8 @@
+<template>
+  <div class="el-checkbox-group" role="group" aria-label="checkbox-group">
+    <slot></slot>
+  </div>
+</template>
 <script>
   import Emitter from 'element-ui/src/mixins/emitter';
 
@@ -40,9 +45,3 @@
     }
   };
 </script>
-
-<template>
-  <div class="el-checkbox-group" role="group" aria-label="checkbox-group">
-    <slot></slot>
-  </div>
-</template>

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -55,6 +55,7 @@
 </template>
 <script>
   import Emitter from 'element-ui/src/mixins/emitter';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElCheckbox',
@@ -146,7 +147,7 @@
       isDisabled() {
         return (this.isGroup
           ? this._checkboxGroup.disabled || this.isLimitDisabled
-          : false) || this.disabled || !!(this.elForm || {}).disabled;
+          : false) || calcDisabled(this.disabled, this.elForm);
       },
 
       _elFormItemSize() {
@@ -165,7 +166,10 @@
       value: {},
       label: {},
       indeterminate: Boolean,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       checked: Boolean,
       name: String,
       trueLabel: [String, Number],

--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -35,6 +35,7 @@
   import PickerDropdown from './components/picker-dropdown.vue';
   import Clickoutside from 'element-ui/src/utils/clickoutside';
   import Emitter from 'element-ui/src/mixins/emitter';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElColorPicker',
@@ -45,7 +46,10 @@
       value: String,
       showAlpha: Boolean,
       colorFormat: String,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       size: String,
       popperClass: String,
       predefine: Array
@@ -80,7 +84,7 @@
       },
 
       colorDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       }
     },
 

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -90,6 +90,8 @@ import { formatDate, parseDate, isDateObject, getWeekNumber } from 'element-ui/s
 import { customerPopper } from 'element-ui/src/utils/vue-popper';
 import Emitter from 'element-ui/src/mixins/emitter';
 import ElInput from 'element-ui/packages/input';
+import { calcDisabled } from 'element-ui/src/utils/util';
+
 const poperMixins = customerPopper('reference');
 
 const DEFAULT_FORMATS = {
@@ -340,7 +342,10 @@ export default {
       default: '',
       validator
     },
-    disabled: Boolean,
+    disabled: {
+      type: Boolean,
+      default: null
+    },
     clearable: {
       type: Boolean,
       default: true
@@ -541,7 +546,7 @@ export default {
     },
 
     pickerDisabled() {
-      return this.disabled || !!(this.elForm || {}).disabled;
+      return calcDisabled(this.disabled, this.elForm);
     },
 
     firstInputId() {

--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -1,8 +1,9 @@
 <template>
-  <form class="el-form" :class="[
-    labelPosition ? 'el-form--label-' + labelPosition : '',
-    { 'el-form--inline': inline }
-  ]">
+  <form class="el-form" :class="{
+    ['el-form--label-' + labelPosition]: labelPosition,
+    'el-form--inline': inline,
+    'el-form--disabled': disabled
+  }">
     <slot></slot>
   </form>
 </template>

--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -49,6 +49,7 @@
   import ElInput from 'element-ui/packages/input';
   import Focus from 'element-ui/src/mixins/focus';
   import RepeatClick from 'element-ui/src/directives/repeat-click';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElInputNumber',
@@ -85,7 +86,10 @@
         default: -Infinity
       },
       value: Number,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       size: String,
       controls: {
         type: Boolean,
@@ -152,7 +156,7 @@
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;
       },
       inputNumberDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       },
       displayValue() {
         if (this.userInput !== null) {

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -121,7 +121,7 @@
   import Migrating from 'element-ui/src/mixins/migrating';
   import calcTextareaHeight from './calcTextareaHeight';
   import merge from 'element-ui/src/utils/merge';
-  import {isKorean} from 'element-ui/src/utils/util';
+  import { isKorean, calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElInput',
@@ -156,7 +156,10 @@
       size: String,
       resize: String,
       form: String,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       readonly: Boolean,
       type: {
         type: String,
@@ -225,10 +228,10 @@
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;
       },
       inputDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       },
       nativeInputValue() {
-        return this.value === null || this.value === undefined ? '' : String(this.value);
+        return this.value == null ? '' : String(this.value);
       },
       showClear() {
         return this.clearable &&

--- a/packages/link/src/main.vue
+++ b/packages/link/src/main.vue
@@ -1,10 +1,10 @@
 <template>
   <a
+    class="el-link"
     :class="[
-      'el-link',
       type ? `el-link--${type}` : '',
-      disabled && 'is-disabled',
-      underline && !disabled && 'is-underline',
+      linkDisabled && 'is-disabled',
+      underline && !linkDisabled && 'is-underline',
       inheritFs && 'is-inherit-fs'
     ]"
     :href="tHref"
@@ -20,9 +20,16 @@
 </template>
 
 <script>
+import { calcDisabled } from 'element-ui/src/utils/util';
 
 export default {
   name: 'ElLink',
+
+  inject: {
+    elForm: {
+      default: ''
+    }
+  },
 
   props: {
     type: {
@@ -33,7 +40,10 @@ export default {
       type: Boolean,
       default: true
     },
-    disabled: Boolean,
+    disabled: {
+      type: Boolean,
+      default: null
+    },
     href: String,
     to: [String, Object],
     icon: String,
@@ -65,6 +75,9 @@ export default {
         return this.$router.resolve(this.to).href;
       }
       return this.href;
+    },
+    linkDisabled() {
+      return calcDisabled(this.disabled, this.elForm);
     }
   }
 };

--- a/packages/radio/src/radio-button.vue
+++ b/packages/radio/src/radio-button.vue
@@ -53,7 +53,10 @@
 
     props: {
       label: {},
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       name: String
     },
     data() {

--- a/packages/radio/src/radio.vue
+++ b/packages/radio/src/radio.vue
@@ -44,6 +44,7 @@
 </template>
 <script>
   import Emitter from 'element-ui/src/mixins/emitter';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElRadio',
@@ -65,7 +66,10 @@
     props: {
       value: {},
       label: {},
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       name: String,
       border: Boolean,
       size: String
@@ -114,7 +118,7 @@
       isDisabled() {
         return (this.isGroup
           ? this._radioGroup.disabled
-          : false) || this.disabled || !!(this.elForm || {}).disabled;
+          : false) || calcDisabled(this.disabled, this.elForm);
       },
       tabIndex() {
         return (this.isDisabled || (this.isGroup && this.model !== this.label)) ? -1 : 0;

--- a/packages/rate/src/main.vue
+++ b/packages/rate/src/main.vue
@@ -35,6 +35,7 @@
 <script>
   import { hasClass } from 'element-ui/src/utils/dom';
   import Migrating from 'element-ui/src/mixins/migrating';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElRate',
@@ -213,7 +214,7 @@
       },
 
       rateDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -148,7 +148,7 @@
   import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
   import { t } from 'element-ui/src/locale';
   import scrollIntoView from 'element-ui/src/utils/scroll-into-view';
-  import { getValueByPath, valueEquals, isIE, isEdge, isKorean } from 'element-ui/src/utils/util';
+  import { getValueByPath, valueEquals, isIE, isEdge, isKorean, calcDisabled } from 'element-ui/src/utils/util';
   import NavigationMixin from './navigation-mixin';
 
   export default {
@@ -228,7 +228,7 @@
       },
 
       selectDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       },
 
       collapseTagSize() {
@@ -269,7 +269,10 @@
       },
       automaticDropdown: Boolean,
       size: String,
-      disabled: Boolean,
+      disabled: {
+        type: Boolean,
+        default: null
+      },
       clearable: Boolean,
       filterable: Boolean,
       allowCreate: Boolean,

--- a/packages/slider/src/mixin.js
+++ b/packages/slider/src/mixin.js
@@ -1,5 +1,6 @@
 import Emitter from 'element-ui/src/mixins/emitter';
 import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
+import { calcDisabled } from 'element-ui/src/utils/util';
 
 import SliderButton from './button.vue';
 import SliderCommon from './common.jsx';
@@ -133,7 +134,7 @@ export default {
     },
 
     sliderDisabled() {
-      return this.disabled || !!(this.elForm || {}).disabled;
+      return calcDisabled(this.disabled, this.elForm);
     },
 
     barStyle() {

--- a/packages/switch/src/component.vue
+++ b/packages/switch/src/component.vue
@@ -44,6 +44,7 @@
   import emitter from 'element-ui/src/mixins/emitter';
   import Focus from 'element-ui/src/mixins/focus';
   import Migrating from 'element-ui/src/mixins/migrating';
+  import { calcDisabled } from 'element-ui/src/utils/util';
 
   export default {
     name: 'ElSwitch',
@@ -112,7 +113,7 @@
         return this.value === this.activeValue;
       },
       switchDisabled() {
-        return this.disabled || !!(this.elForm || {}).disabled;
+        return calcDisabled(this.disabled, this.elForm);
       },
       coreStyle() {
         const color = this.checked ? this.activeColor : this.inactiveColor;

--- a/packages/tabs/src/tab-nav.vue
+++ b/packages/tabs/src/tab-nav.vue
@@ -1,8 +1,8 @@
 <script>
   import TabBar from './tab-bar';
   import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
+  import { noop } from 'element-ui/src/utils/util';
 
-  function noop() {}
   const firstUpperCase = str => {
     return str.toLowerCase().replace(/( |^)[a-z]/g, (L) => L.toUpperCase());
   };

--- a/packages/upload/src/index.js
+++ b/packages/upload/src/index.js
@@ -1,10 +1,8 @@
-<script>
 import UploadList from './upload-list';
 import Upload from './upload';
 import ElProgress from 'element-ui/packages/progress';
 import Migrating from 'element-ui/src/mixins/migrating';
-
-function noop() {}
+import { calcDisabled, noop } from 'element-ui/src/utils/util';
 
 export default {
   name: 'ElUpload',
@@ -98,7 +96,10 @@ export default {
       default: 'text' // text,picture,picture-card
     },
     httpRequest: Function,
-    disabled: Boolean,
+    disabled: {
+      type: Boolean,
+      default: null
+    },
     limit: Number,
     onExceed: {
       type: Function,
@@ -117,7 +118,7 @@ export default {
 
   computed: {
     uploadDisabled() {
-      return this.disabled || !!(this.elForm || {}).disabled;
+      return calcDisabled(this.disabled, this.elForm);
     }
   },
 
@@ -335,4 +336,3 @@ export default {
     );
   }
 };
-</script>

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -271,3 +271,14 @@ export function isKorean(text) {
   const reg = /([(\uAC00-\uD7AF)|(\u3130-\u318F)])+/gi;
   return reg.test(text);
 }
+
+/**
+ * @param {boolean} currentDisabled
+ * @param {import('element-ui').Form} elForm
+ **/
+export function calcDisabled(currentDisabled, elForm) {
+  if (currentDisabled == null) {
+    return !!elForm && !!elForm.disabled;
+  }
+  return !!currentDisabled;
+}

--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -80,7 +80,37 @@ describe('Form', () => {
     const newMarginLeft = parseInt(formItem.style.marginLeft, 10);
     expect(newMarginLeft < marginLeft).to.be.true;
   });
-  it('inline form', done => {
+  it('disable form', () => {
+    vm = createVue({
+      template: `
+        <el-form ref="form" :model="form" disabled>
+          <el-form-item>
+            <el-input ref="text1" v-model="form.text1"></el-input>
+          </el-form-item>
+          <el-form-item>
+            <el-input ref="text2" v-model="form.text2" :disabled="true"></el-input>
+          </el-form-item>
+          <el-form-item>
+            <el-input ref="text3" v-model="form.text3" :disabled="false"></el-input>
+          </el-form-item>
+        </el-form>
+      `,
+      data() {
+        return {
+          form: {
+            text1: '',
+            text2: '',
+            text3: ''
+          }
+        };
+      }
+    }, true);
+    expect(vm.$el.classList.contains('el-form--disabled')).to.be.true;
+    expect(vm.$refs.text1.$el.classList.contains('is-disabled')).to.be.true;
+    expect(vm.$refs.text2.$el.classList.contains('is-disabled')).to.be.true;
+    expect(vm.$refs.text3.$el.classList.contains('is-disabled')).to.be.false;
+  });
+  it('inline form', () => {
     vm = createVue({
       template: `
         <el-form ref="form" :model="form" inline>
@@ -102,9 +132,8 @@ describe('Form', () => {
       }
     }, true);
     expect(vm.$el.classList.contains('el-form--inline')).to.be.true;
-    done();
   });
-  it('label position', done => {
+  it('label position', () => {
     vm = createVue({
       template: `
         <div>
@@ -137,7 +166,6 @@ describe('Form', () => {
     }, true);
     expect(vm.$refs.labelTop.$el.classList.contains('el-form--label-top')).to.be.true;
     expect(vm.$refs.labelLeft.$el.classList.contains('el-form--label-left')).to.be.true;
-    done();
   });
   it('label size', () => {
     vm = createVue({


### PR DESCRIPTION
允许被禁用的表单下有非禁用的组件

Breaking change: now `:disabled="true"` only disable components
that don't set `disabled` prop ( i.e. `:disabled="null"`)

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
