### PR TITLE
button/link: don't use `el-icon--{left,right}`

### DIFF
--- a/packages/button/src/button.vue
+++ b/packages/button/src/button.vue
@@ -17,12 +17,13 @@
   >
     <i
       v-if="icon || loading"
-      :class="[
-        loading ? 'el-icon-loading' : icon,
-        $slots.default ? 'el-icon--left' : null
-      ]"></i>
+      :class="loading ? 'el-icon-loading' : icon"
+      :style="$slots.default ? { marginRight: '5px' } : null"></i>
     <slot></slot>
-    <i class="el-icon--right" :class="iconRight" v-if="iconRight"></i>
+    <i
+      v-if="iconRight"
+      :class="iconRight"
+      :style="iconRight ? { marginLeft: '5px' } : null"></i>
   </button>
 </template>
 <script>

--- a/packages/link/src/main.vue
+++ b/packages/link/src/main.vue
@@ -11,11 +11,17 @@
     v-bind="$attrs"
     @click="handleClick"
   >
-    <i :class="[icon, $slots.default ? 'el-icon--left' : null]" v-if="icon"></i>
+    <i
+      v-if="icon"
+      :class="icon"
+      :style="$slots.default ? { marginRight: '5px' } : null"></i>
 
     <slot></slot>
 
-    <i :class="[iconRight, $slots.default ? 'el-icon--right' : null]" v-if="iconRight"></i>
+    <i
+      v-if="iconRight"
+      :class="iconRight"
+      :style="iconRight ? { marginLeft: '5px' } : null"></i>
   </a>
 </template>
 

--- a/test/unit/specs/button.spec.js
+++ b/test/unit/specs/button.spec.js
@@ -21,7 +21,8 @@ describe('Button', () => {
     let buttonElm = vm.$el;
     const ico = buttonElm.querySelector('.el-icon-search');
     expect(ico).to.be.ok;
-    expect(ico.classList.contains('el-icon--left')).to.be.false;
+    expect(ico.style.marginLeft).to.be.equal('');
+    expect(ico.style.marginRight).to.be.equal('');
   });
   it('icon with content', () => {
     vm = createVue({
@@ -32,7 +33,7 @@ describe('Button', () => {
     let buttonElm = vm.$el;
     const ico = buttonElm.querySelector('.el-icon-search');
     expect(ico).to.be.ok;
-    expect(ico.classList.contains('el-icon--left')).to.be.true;
+    expect(ico.style.marginRight).to.be.equal('5px');
   });
   it('icon right with content', () => {
     vm = createVue({
@@ -43,7 +44,7 @@ describe('Button', () => {
     let buttonElm = vm.$el;
     const ico = buttonElm.querySelector('.el-icon-search');
     expect(ico).to.be.ok;
-    expect(ico.classList.contains('el-icon--right')).to.be.true;
+    expect(ico.style.marginLeft).to.be.equal('5px');
   });
   it('nativeType', () => {
     vm = createTest(Button, {


### PR DESCRIPTION
Any elements contains `el-icon-` in their className is considered an
element icon, and set `font-family: 'element-icons' !important`

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
