### PR TITLE
form: make Promise form of ElForm::validate returns invalid fields

### DIFF
--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -798,6 +798,36 @@ describe('Form', () => {
         done();
       });
     });
+    it('validate field promise', () => {
+      vm = createVue({
+        template: `
+          <el-form :model="form" :rules="rules" ref="form">
+            <el-form-item label="活动名称" prop="name" ref="field">
+              <el-input v-model="form.name"></el-input>
+            </el-form-item>
+          </el-form>
+        `,
+        data() {
+          return {
+            form: {
+              name: ''
+            },
+            rules: {
+              name: [
+                { required: true, message: '请输入活动名称', trigger: 'change', min: 3, max: 6 }
+              ]
+            }
+          };
+        },
+        methods: {
+          setValue(value) {
+            this.form.name = value;
+          }
+        }
+      }, true);
+      return vm.$refs.form.validateField('name')
+        .then(() => { throw new Error('failed'); }, () => {});
+    });
     it('custom validate', done => {
       var checkName = (rule, value, callback) => {
         if (value.length < 5) {
@@ -920,7 +950,7 @@ describe('Form', () => {
         done();
       });
     });
-    it('validate return promise', done => {
+    it('validate return promise', () => {
       var checkName = (rule, value, callback) => {
         if (value.length < 5) {
           callback(new Error('长度至少为5'));
@@ -949,9 +979,10 @@ describe('Form', () => {
           };
         }
       }, true);
-      vm.$refs.form.validate().catch(validFailed => {
-        expect(validFailed).to.false;
-        done();
+      return vm.$refs.form.validate().then(() => {
+        throw new Error('failed');
+      }, validFailed => {
+        return expect(validFailed.name.length).to.eq(1);
       });
     });
   });

--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -65,14 +65,15 @@ export declare class ElForm extends ElementUIComponent {
    * @param callback A callback to tell the validation result
    */
   validate (callback: ValidateCallback): void
-  validate (): Promise<boolean>
+  validate (): Promise<object>
   /**
    * Validate certain form items
    *
    * @param props The property of `model` or array of prop which is going to validate
    * @param callback A callback to tell the field validation result
    */
-  validateField (props: string | string[], callback?: ValidateFieldCallback): void
+  validateField (props: string | string[], callback: ValidateFieldCallback): void
+  validateField (props: string | string[]): Promise<object>
 
   /** reset all the fields and remove validation result */
   resetFields (): void


### PR DESCRIPTION
当validate失败时，返回的promise中带非法的字段对象列表

make ElForm::validateField without callback parameter returns Promise

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
